### PR TITLE
Added GitHub testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,66 @@
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    name: "Test"
+    runs-on: "windows-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        jdkconf:
+          - JDK 8
+          - JDK 11
+          - JDK 17
+        include:
+          - jdkconf: JDK 8
+            jdkver: "8"
+          - jdkconf: JDK 11
+            jdkver: "11"
+          - jdkconf: JDK 17
+            jdkver: "17"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: wget tar
+      - name: Prepare env
+        shell: msys2 {0}
+        run: |
+          mkdir input
+          echo "JDK_VERSION_INPUT=${{ matrix.jdkver }}" >> $GITHUB_ENV
+          echo "MSI_VENDOR_INPUT=Adoptium" >> $GITHUB_ENV
+          echo "RESULTS_FOLDER_NAME=results" >> $GITHUB_ENV
+          echo "CURRENT_USER_NAME_INPUT=runneradmin" >> $GITHUB_ENV
+      - name: Download Installer
+        shell: msys2 {0}
+        run: |
+          wget -O "input/installer.msi" "https://api.adoptium.net/v3/installer/latest/${{ matrix.jdkver }}/ga/windows/x64/jdk/hotspot/normal/eclipse?project=jdk"
+          ls -lah input
+      - name: Run
+        shell: msys2 {0}
+        timeout-minutes: 30
+        run: MSYS2_ARG_CONV_EXCL='*' ./wrapper/run-tps-win-vagrant.sh
+      - name: Check results
+        if: ${{ always() }}
+        shell: msys2 {0}
+        run: |
+          cat "results/results.txt"
+          ! grep -qi '^FAILED' "results/results.txt"
+      - name: Pack results
+        if: ${{ always() }}
+        shell: msys2 {0}
+        run: |
+          tar -C results -czf "results-jdk${{ matrix.jdkver }}.tar.gz" .
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          path: "results-jdk${{ matrix.jdkver }}.tar.gz"
+        continue-on-error: true

--- a/wrapper/configure-vendor-specific-settings.sh
+++ b/wrapper/configure-vendor-specific-settings.sh
@@ -11,7 +11,7 @@ function setupVendorSpecific() {
 
 function configureAdoptiumSpecificSettings() {
   # check if this is the default configuration
-  INSTALL_MODULES=FeatureMain,FeatureJavaHome,FeatureJarFileRunWith
+  export INSTALL_MODULES=FeatureMain,FeatureJavaHome,FeatureJarFileRunWith
 
   # todorc: configure Adoptium registry values
 }

--- a/wrapper/run-folder-as-tests.sh
+++ b/wrapper/run-folder-as-tests.sh
@@ -35,7 +35,6 @@ export RESULTS_FOLDER=$SCRIPT_DIR/../$RESULTS_FOLDER_NAME
 rm -rf "${SCRIPT_DIR:?}"/"$SUITE"
 set -x
 mkdir "$RESULTS_FOLDER"
-rpm -qa | sort > "$RESULTS_FOLDER"/rpms.txt
 if [ "$?" -ne "0" ]; then
   let FAILED_TESTS=$FAILED_TESTS+1
 fi


### PR DESCRIPTION
This adds GitHub testing using Adoptium Windows builds. Two additional small fixes were required.

Tests are not green as some test cases are currently failing. However based on [todo](https://github.com/zzambers/WindowsTPS/blob/ffadb9dfb338fe7c10dc24454161658caed73af6/wrapper/configure-vendor-specific-settings.sh#L16) comment in Adoptium configuration, support for Adoptium seems incomplete, so failures are probably expected at this point.
