### PR TITLE
Fix configuration variables

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,10 +34,10 @@ jobs:
         shell: msys2 {0}
         run: |
           mkdir input
-          echo "JDK_VERSION_INPUT=${{ matrix.jdkver }}" >> $GITHUB_ENV
-          echo "MSI_VENDOR_INPUT=Adoptium" >> $GITHUB_ENV
-          echo "RESULTS_FOLDER_NAME=results" >> $GITHUB_ENV
-          echo "CURRENT_USER_NAME_INPUT=runneradmin" >> $GITHUB_ENV
+          echo "JDK_VERSION=${{ matrix.jdkver }}" >> $GITHUB_ENV
+          echo "MSI_VENDOR=Adoptium" >> $GITHUB_ENV
+          echo "INPUT_FOLDER=input" >> $GITHUB_ENV
+          echo "RESULTS_FOLDER=results" >> $GITHUB_ENV
       - name: Download Installer
         shell: msys2 {0}
         run: |

--- a/README.md
+++ b/README.md
@@ -10,20 +10,24 @@ Run folder `tps` directory as tests
 
 ## Configuration 
 
-### RESULTS_FOLDER_NAME
-Use RESULTS_FOLDER_NAME for the name of the folder where the results will be stored. 
+### RESULTS_FOLDER
+Use RESULTS_FOLDER for the name of the folder where the results will be stored.
+Default: results
 
 ### OTOOL_JDK_VERSION
 Use OTOOL_JDK_VERSION for defition of java version. The corresponding subset of tests will be used.
 
 ### MSI_VENDOR
-Use MSI_VENDOR for defining vender specific settings used for test run.
+Use MSI_VENDOR for defining vender specific settings used for test run. (Adoptium or RH)
+Default: RH
 
 ### INPUT_FOLDER
 Use INPUT_FOLDER used for testing (including MSI)
+Default: input
 
 ### CURRENT_USER_NAME
 Use CURRENT_USER_NAME for definiton of user under which the tests will run.
+Default: $USER value
 
 # Credits
 This project would never be created without extensive help of

--- a/wrapper/run-folder-as-tests.sh
+++ b/wrapper/run-folder-as-tests.sh
@@ -30,7 +30,8 @@ ALL_TESTS=0
 PASSED_TESTS=0
 SKIPPED_TESTS=0
 tmpXmlBodyFile=$(mktemp)
-export RESULTS_FOLDER=$SCRIPT_DIR/../$RESULTS_FOLDER_NAME
+export RESULTS_FOLDER="$( readlink -m "$RESULTS_FOLDER" )"
+export INPUT_FOLDER="$( readlink -m "$INPUT_FOLDER" )"
 
 rm -rf "${SCRIPT_DIR:?}"/"$SUITE"
 set -x

--- a/wrapper/run-tps-win-vagrant.sh
+++ b/wrapper/run-tps-win-vagrant.sh
@@ -17,29 +17,29 @@ set -x
 set -e
 set -o pipefail
 
-# propagate RESULTS_FOLDER_NAME_INPUT for the custom path for storing tests results here
+# propagate RESULTS_FOLDER, if set, for the custom path for storing tests results here
 # otherwise results folder will be used
-export RESULTS_FOLDER_NAME="${RESULTS_FOLDER_NAME_INPUT:-results}" 
+export RESULTS_FOLDER="${RESULTS_FOLDER:-results}"
 
-# propagate JDK_VERSION_INPUT for definition of which subset of tests should run
+# propagate JDK_VERSION, if set, for definition of which subset of tests should run
 # otherwise version 11 will be used
-export OTOOL_JDK_VERSION="${JDK_VERSION_INPUT:-11}" #todorc: implement detection of java version
+export OTOOL_JDK_VERSION="${OTOOL_JDK_VERSION:-${JDK_VERSION:-11}}" #todorc: implement detection of java version
 
-# propagate MSI_VENDOR_INPUT variable>
+# propagate MSI_VENDOR variable, if set,
 # this will ensure vendor-specific parts of tests will be applied
 # otherwise RH will be used
 # Possible implemented values are Adoptium and RH
 # You can configure specifics in configure-vendor-specific-settings.sh
-export MSI_VENDOR="${MSI_VENDOR_INPUT:-RH}"
+export MSI_VENDOR="${MSI_VENDOR:-RH}"
 
-# propagate INPUT_PATH_INPUT to folder containing one msi used for tests
-# otherwise ../input folder will be used
-export INPUT_FOLDER=$SCRIPT_DIR"${INPUT_PATH_INPUT:-/../input}"
+# propagate INPUT_FOLDER, if set, to folder containing one msi used for tests
+# otherwise input folder will be used
+export INPUT_FOLDER="${INPUT_FOLDER:-input}"
 
-# propagate CURRENT_USER_INPUT
+# propagate CURRENT_USER, if set,
 # this should contain user used for testing
-# by default tester is used
-export CURRENT_USER_NAME="${CURRENT_USER_NAME_INPUT:-tester}"
+# by default $USER
+export CURRENT_USER_NAME="${CURRENT_USER_NAME:-$USER}"
 
 export INSTALL_DIR_INPUT=C:\\\\Users\\\\$CURRENT_USER_NAME\\\\java
 


### PR DESCRIPTION
Configuration variables fixed:
- _INPUT suffix no longer used
- `INPUT_FOLDER` and `RESULTS_FOLDER` accepts normal pathes (both relative and absolute)
- README and comments updated