### PR TITLE
re-introduced tester as current user name default value

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
           echo "MSI_VENDOR=Adoptium" >> $GITHUB_ENV
           echo "INPUT_FOLDER=input" >> $GITHUB_ENV
           echo "RESULTS_FOLDER=results" >> $GITHUB_ENV
+          echo "CURRENT_USER_NAME=runneradmin" >> $GITHUB_ENV
       - name: Download Installer
         shell: msys2 {0}
         run: |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Default: input
 ### CURRENT_USER_NAME
 Use CURRENT_USER_NAME for definiton of user under which the tests will run.  
 This is used as the root directory for installation, saving logs etc.  
-Default: $USER value
+Default: tester
 
 # Credits
 This project would never be created without extensive help of

--- a/wrapper/run-tps-win-vagrant.sh
+++ b/wrapper/run-tps-win-vagrant.sh
@@ -38,8 +38,8 @@ export INPUT_FOLDER="${INPUT_FOLDER:-input}"
 
 # propagate CURRENT_USER, if set,
 # this should contain user used for testing
-# by default $USER
-export CURRENT_USER_NAME="${CURRENT_USER_NAME:-$USER}"
+# by default tester
+export CURRENT_USER_NAME="${CURRENT_USER_NAME:-tester}"
 
 export INSTALL_DIR_INPUT=C:\\\\Users\\\\$CURRENT_USER_NAME\\\\java
 


### PR DESCRIPTION
In previous changes, we introduced the usage of $USER and removed the default tester fallback. 

For the Adoptium run is better to let this fallback so this reverts previous changes related to the default user.