### PR TITLE
Excluded 0044 from for Adoptium on java 19

### DIFF
--- a/tps/0044_SDK_lib_server_exists.sh
+++ b/tps/0044_SDK_lib_server_exists.sh
@@ -21,6 +21,11 @@ source "$SCRIPT_DIR/testlib.bash"
 parseArguments "$@"
 processArguments
 
+if [ "$MSI_VENDOR" == "Adoptium" ] && [[ "$OTOOL_JDK_VERSION" -eq 19 ]]; then
+    echo "$NOT_IMPLEMENTED_ON_ADOPTIUM"
+    exit 0   
+fi
+
 
 if [[ $OTOOL_JDK_VERSION -eq 8 ]]; then
   echo $NOT_VALID_ON_OJDK_8


### PR DESCRIPTION
Excluded this test to not fail pipelines like this - https://github.com/rh-openjdk/WindowsTPS/actions/runs/4365175766

It'll be fixed in #24 or #35.

Closes #35 