### PR TITLE
Update GH Actions to work with jdk 20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           - JDK 8
           - JDK 11
           - JDK 17
-          - JDK 19
+          - JDK 20
         include:
           - jdkconf: JDK 8
             jdkver: "8"
@@ -25,8 +25,8 @@ jobs:
             jdkver: "11"
           - jdkconf: JDK 17
             jdkver: "17"
-          - jdkconf: JDK 19
-            jdkver: "19"
+          - jdkconf: JDK 20
+            jdkver: "20"
     steps:
       - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2


### PR DESCRIPTION
JDK 20 has been released and we need to run against the latest version.