### PR TITLE
Exclude 044 on the latest java

### DIFF
--- a/tps/0044_SDK_lib_server_exists.sh
+++ b/tps/0044_SDK_lib_server_exists.sh
@@ -21,7 +21,7 @@ source "$SCRIPT_DIR/testlib.bash"
 parseArguments "$@"
 processArguments
 
-if [ "$MSI_VENDOR" == "Adoptium" ] && [[ "$OTOOL_JDK_VERSION" -eq 19 ]]; then
+if [ "$MSI_VENDOR" == "Adoptium" ] && [[ "$OTOOL_JDK_VERSION" -eq 20 ]]; then
     echo "$NOT_IMPLEMENTED_ON_ADOPTIUM"
     exit 0   
 fi


### PR DESCRIPTION
This exclusion should fix failing GH action against the latest java released recently.

Fixes #45 

Implementation will be done in #36 

